### PR TITLE
Add support for configuring encryption for sql server

### DIFF
--- a/misc/python/materialize/mzcompose/services/sql_server.py
+++ b/misc/python/materialize/mzcompose/services/sql_server.py
@@ -23,7 +23,8 @@ class SqlServer(Service):
         # lowercase letters, base-10 digits and/or non-alphanumeric symbols.
         sa_password: str = DEFAULT_SA_PASSWORD,
         name: str = "sql-server",
-        image: str = "mcr.microsoft.com/mssql/server",
+        # 2017 mssql images core on OSx, 2019 is the earliest that has passed
+        image: str = "mcr.microsoft.com/mssql/server:2019-CU32-ubuntu-20.04",
         environment_extra: list[str] = [],
         volumes_extra: list[str] = [],
     ) -> None:

--- a/src/sql-server-util/src/config.rs
+++ b/src/sql-server-util/src/config.rs
@@ -120,3 +120,14 @@ impl From<EncryptionLevel> for tiberius::EncryptionLevel {
         }
     }
 }
+
+/// Policy that dictates validation of the SQL-SERVER certificate.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Arbitrary, Serialize, Deserialize)]
+pub enum CertificateValidationPolicy {
+    /// Don't validate the server's certificate; trust all certificates.
+    TrustAll,
+    /// Validate server's certificate using system certificates.
+    VerifySystem,
+    /// Validate server's certifiacte using provided CA certificate.
+    VerifyCA,
+}

--- a/src/storage-types/src/connections.proto
+++ b/src/storage-types/src/connections.proto
@@ -142,6 +142,8 @@ message ProtoSqlServerConnectionDetails {
   mz_repr.catalog_item_id.ProtoCatalogItemId password = 5;
   ProtoTunnel tunnel = 6;
   ProtoSqlServerEncryptionLevel encryption = 7;
+  ProtoSqlServerCertificateValidationPolicy certificate_validation_policy = 8;
+  string_or_secret.ProtoStringOrSecret tls_root_cert = 9;
 }
 
 enum ProtoSqlServerEncryptionLevel {
@@ -149,4 +151,10 @@ enum ProtoSqlServerEncryptionLevel {
   SQL_SERVER_LOGIN = 1;
   SQL_SERVER_PREFERRED = 2;
   SQL_SERVER_REQUIRED = 3;
+}
+
+enum ProtoSqlServerCertificateValidationPolicy {
+  SQL_SERVER_TRUST_ALL = 0;
+  SQL_SERVER_VERIFY_SYSTEM = 1;
+  SQL_SERVER_VERIFY_CA = 2;
 }

--- a/test/sql-server-cdc/11-sql-server-cdc-ssl.td
+++ b/test/sql-server-cdc/11-sql-server-cdc-ssl.td
@@ -1,0 +1,132 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Setup SQL Server state.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_sql_server_source = true;
+
+> CREATE SECRET ssl_ca AS '${arg.ssl-ca}'
+> CREATE SECRET alt_ssl_ca AS '${arg.alt-ssl-ca}'
+> CREATE SECRET IF NOT EXISTS sql_server_pass AS '${arg.default-sql-server-password}'
+
+# Create a table that has CDC enabled.
+
+$ sql-server-connect name=sql-server
+server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=${arg.default-sql-server-user};Password=${arg.default-sql-server-password}
+
+$ sql-server-execute name=sql-server
+DROP DATABASE IF EXISTS test_ssl;
+CREATE DATABASE test_ssl;
+USE test_ssl;
+
+EXEC sys.sp_cdc_enable_db;
+ALTER DATABASE test_ssl SET ALLOW_SNAPSHOT_ISOLATION ON;
+
+CREATE TABLE t1_pk (key_col VARCHAR(20) PRIMARY KEY, val_col VARCHAR(1024));
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 't1_pk', @role_name = 'SA', @supports_net_changes = 0;
+
+INSERT INTO t1_pk VALUES ('a', 'hello world'), ('b', 'foobar'), ('c', 'anotha one');
+
+CREATE TABLE t2_no_cdc (key_col VARCHAR(20) PRIMARY KEY, val_col VARCHAR(1024));
+
+CREATE TABLE t3_text (value VARCHAR(100));
+EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 't3_text', @role_name = 'SA', @supports_net_changes = 0;
+
+# Exercise Materialize.
+
+# Test SSL MODE disabled.
+
+> CREATE CONNECTION no_ssl_connection TO SQL SERVER (
+    HOST 'sql-server',
+    PORT 1433,
+    DATABASE test_ssl,
+    USER '${arg.default-sql-server-user}',
+    PASSWORD = SECRET sql_server_pass,
+    SSL MODE disabled
+  );
+
+> VALIDATE CONNECTION no_ssl_connection;
+
+> SELECT name, type from mz_connections WHERE name = 'no_ssl_connection';
+name                    type
+---------------------------------------
+no_ssl_connection       sql-server
+
+
+> DROP CONNECTION no_ssl_connection;
+
+# Test SSL MODE required.
+> CREATE CONNECTION required_ssl_connection TO SQL SERVER (
+    HOST 'sql-server',
+    PORT 1433,
+    DATABASE test_ssl,
+    USER '${arg.default-sql-server-user}',
+    PASSWORD = SECRET sql_server_pass,
+    SSL MODE required
+  );
+
+> VALIDATE CONNECTION required_ssl_connection;
+
+> SELECT name, type from mz_connections WHERE name = 'required_ssl_connection';
+name                      type
+---------------------------------------
+required_ssl_connection   sql-server
+
+> DROP CONNECTION required_ssl_connection;
+
+
+# Test SSL MODE verify_ca.''
+# verify_ca requires a CA
+! CREATE CONNECTION missing_ca TO SQL SERVER (
+    HOST 'sql-server',
+    PORT 1433,
+    DATABASE test_ssl,
+    USER '${arg.default-sql-server-user}',
+    PASSWORD SECRET sql_server_pass,
+    SSL MODE verify_ca
+  );
+contains:invalid CONNECTION: SSL MODE 'verify_ca' requires SSL CERTIFICATE AUTHORITY
+
+# verify_ca fails with incorrect CA
+! CREATE CONNECTION invalid_ca TO SQL SERVER (
+    HOST 'sql-server',
+    PORT 1433,
+    DATABASE test_ssl,
+    USER '${arg.default-sql-server-user}',
+    PASSWORD SECRET sql_server_pass,
+    SSL MODE verify_ca,
+    SSL CERTIFICATE AUTHORITY SECRET alt_ssl_ca
+  );
+contains:certificate verify failed
+
+> SELECT count(*) from mz_connections WHERE name = 'invalid_ca';
+0
+
+
+# verify_ca works with correct CA
+> CREATE CONNECTION verify_ca_ssl_connection TO SQL SERVER (
+    HOST 'sql-server',
+    PORT 1433,
+    DATABASE test_ssl,
+    USER '${arg.default-sql-server-user}',
+    PASSWORD SECRET sql_server_pass,
+    SSL MODE verify_ca,
+    SSL CERTIFICATE AUTHORITY SECRET ssl_ca
+  );
+
+> VALIDATE CONNECTION verify_ca_ssl_connection;
+
+> SELECT name, type from mz_connections WHERE name = 'verify_ca_ssl_connection';
+name                       type
+---------------------------------------
+verify_ca_ssl_connection   sql-server
+
+
+> DROP CONNECTION verify_ca_ssl_connection;

--- a/test/sql-server-cdc/mzcompose.py
+++ b/test/sql-server-cdc/mzcompose.py
@@ -26,7 +26,11 @@ TLS_CONF_PATH = MZ_ROOT / "test" / "sql-server-cdc" / "tls-mssconfig.conf"
 
 SERVICES = [
     Mz(app_password=""),
-    Materialized(),
+    Materialized(
+        additional_system_parameter_defaults={
+            "log_filter": "mz_storage::source::sql-server=debug,mz_sql_server_util=debug,info"
+        },
+    ),
     Testdrive(),
     TestCerts(),
     SqlServer(
@@ -64,8 +68,17 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     c.kill("materialized")
     c.rm("materialized")
 
-    c.up("materialized", "sql-server")
+    # must start test-certs, otherwise the certificates needed by sql-server may not be avaiable
+    # in the secrets volume when it starts up
+    c.up("materialized", "test-certs", "sql-server")
     seed = random.getrandbits(16)
+
+    ssl_ca = c.exec(
+        "sql-server", "cat", "/var/opt/mssql/certs/ca.crt", capture=True
+    ).stdout
+    alt_ssl_ca = c.exec(
+        "sql-server", "cat", "/var/opt/mssql/certs/ca-selective.crt", capture=True
+    ).stdout
 
     c.test_parts(
         matching_files,
@@ -73,6 +86,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             "--no-reset",
             "--max-errors=1",
             f"--seed={seed}",
+            f"--var=ssl-ca={ssl_ca}",
+            f"--var=alt-ssl-ca={alt_ssl_ca}",
             f"--var=default-replica-size={Materialized.Size.DEFAULT_SIZE}-{Materialized.Size.DEFAULT_SIZE}",
             f"--var=default-sql-server-user={SqlServer.DEFAULT_USER}",
             f"--var=default-sql-server-password={SqlServer.DEFAULT_SA_PASSWORD}",


### PR DESCRIPTION
Adds support for configuring TLS encryption and custom CA certificate with MS SQL Server 

### Motivation

Implements https://github.com/MaterializeInc/database-issues/issues/9205

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. ([trigger-ci for additional test/nightly runs](https://trigger-ci.dev.materialize.com/))
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] If this PR includes major [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note), I have pinged the relevant PM to schedule a changelog post.
